### PR TITLE
Fix to django.contrib.markup.templatetags.markup deprecated

### DIFF
--- a/fluent_contents/plugins/markup/backend.py
+++ b/fluent_contents/plugins/markup/backend.py
@@ -3,10 +3,13 @@ The rendering support of the markup plugin.
 
 This simply re-uses Django's template filters to do the formatting,
 """
+from docutils.core import publish_string
+import textile, markdown
+
 from django.core.exceptions import ImproperlyConfigured
-from django.contrib.markup.templatetags import markup
 from django.utils.safestring import SafeData, mark_safe
 from fluent_contents.plugins.markup import appsettings
+
 
 _languageNames = {
     'restructuredtext': 'reStructuredText',
@@ -15,8 +18,10 @@ _languageNames = {
 }
 
 # Copy, and allow adding more options.
-SUPPORTED_LANGUAGES = dict(markup.register.filters.iteritems())
-SUPPORTED_LANGUAGES['markdown'] = lambda text: markup.markdown(text, ','.join(appsettings.FLUENT_MARKUP_MARKDOWN_EXTRAS))
+# Construct own dict now that django.contrib.markup.templatetags.markup is gone
+SUPPORTED_LANGUAGES = {'restructuredtext':lambda text: publish_string(text, writer_name='html'),
+                       'markdown':lambda text: markdown.markdown(text, ','.join(appsettings.FLUENT_MARKUP_MARKDOWN_EXTRAS)),
+                       'textile': lambda text: textile.textile(text)}
 
 if appsettings.FLUENT_MARKUP_USE_DJANGO_MARKUP:
     # With django-markup installed, it can be used instead of the default Django filters.


### PR DESCRIPTION
Fix to move to 1.5 now django.contrib.markup.templatetags.markup import restructuredtext is gone

Django Markup deprecated as per https://docs.djangoproject.com/en/1.5/ref/contrib/markup/
Uses same libraries no new requirements.
