### PR TITLE
Compare original text instead of SafeData

### DIFF
--- a/fluent_contents/plugins/markup/backend.py
+++ b/fluent_contents/plugins/markup/backend.py
@@ -55,7 +55,7 @@ def render_text(text, language=None):
 
     # Convert. The Django markup filters return the literal string on ImportErrors
     markup = filter(text)
-    if not isinstance(markup, SafeData):
+    if markup == text:
         raise ImproperlyConfigured("The '{0}' filter did not update the text. Perhaps the required package for the filter is not installed?".format(language))
 
     return markup


### PR DESCRIPTION
This addresses edoburu/django-fluent-contents#31

I've changed the comparison to match the error message, assuming that this is what we are wanting to check for.
