### PR TITLE
Gist ids are no longer integers

### DIFF
--- a/fluent_contents/plugins/gist/migrations/0002_auto__chg_field_gistitem_gist_id.py
+++ b/fluent_contents/plugins/gist/migrations/0002_auto__chg_field_gistitem_gist_id.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+
+        # Changing field 'GistItem.gist_id'
+        db.alter_column(u'contentitem_gist_gistitem', 'gist_id', self.gf('django.db.models.fields.CharField')(max_length=128))
+
+    def backwards(self, orm):
+
+        # Changing field 'GistItem.gist_id'
+        db.alter_column(u'contentitem_gist_gistitem', 'gist_id', self.gf('django.db.models.fields.IntegerField')())
+
+    models = {
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'fluent_contents.contentitem': {
+            'Meta': {'ordering': "('placeholder', 'sort_order')", 'object_name': 'ContentItem'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language_code': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '15', 'db_index': 'True'}),
+            'parent_id': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'parent_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            'placeholder': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'contentitems'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['fluent_contents.Placeholder']"}),
+            'polymorphic_ctype': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'polymorphic_fluent_contents.contentitem_set'", 'null': 'True', 'to': u"orm['contenttypes.ContentType']"}),
+            'sort_order': ('django.db.models.fields.IntegerField', [], {'default': '1', 'db_index': 'True'})
+        },
+        'fluent_contents.placeholder': {
+            'Meta': {'unique_together': "(('parent_type', 'parent_id', 'slot'),)", 'object_name': 'Placeholder'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'parent_id': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'parent_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']", 'null': 'True', 'blank': 'True'}),
+            'role': ('django.db.models.fields.CharField', [], {'default': "'m'", 'max_length': '1'}),
+            'slot': ('django.db.models.fields.SlugField', [], {'max_length': '50'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'})
+        },
+        u'gist.gistitem': {
+            'Meta': {'ordering': "('placeholder', 'sort_order')", 'object_name': 'GistItem', 'db_table': "u'contentitem_gist_gistitem'", '_ormbases': ['fluent_contents.ContentItem']},
+            u'contentitem_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['fluent_contents.ContentItem']", 'unique': 'True', 'primary_key': 'True'}),
+            'filename': ('django.db.models.fields.CharField', [], {'max_length': '128', 'blank': 'True'}),
+            'gist_id': ('django.db.models.fields.CharField', [], {'max_length': '128'})
+        }
+    }
+
+    complete_apps = ['gist']

--- a/fluent_contents/plugins/gist/models.py
+++ b/fluent_contents/plugins/gist/models.py
@@ -6,7 +6,7 @@ class GistItem(ContentItem):
     """
     A reference to a gist item (gist.github.com) that is rendered as source code.
     """
-    gist_id = models.IntegerField(_("Gist number"), help_text=_('Go to <a href="https://gist.github.com/" target="_blank">https://gist.github.com/</a> and copy the number of the Gist snippet you want to display.'))
+    gist_id = models.CharField(_("Gist number"), max_length=128, help_text=_('Go to <a href="https://gist.github.com/" target="_blank">https://gist.github.com/</a> and copy the number of the Gist snippet you want to display.'))
     filename = models.CharField(_("Gist filename"), max_length=128, blank=True, help_text=_('Leave the filename empty to display all files in the Gist.'))
 
     class Meta:


### PR DESCRIPTION
I was getting errors when trying to add gists. I noticed the gist id field was an integer, but Github has since started using UUIDs. A simple migration to a CharField does the trick.
