### PR TITLE
setup.py: extras_require for picture plugin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
         'oembeditem': ['micawber>=0.2.6'],
         'text': ['django-wysiwyg>=0.5.1'],
         'twitterfeed': ['twitter-text-py>=1.0.3'],
+        'picture': ['django-any-urlfield>=2.1.0', 'django-any-imagefield']
     },
     dependency_links = [
         'git+https://github.com/philomat/django-form-designer.git#egg=django-form-designer-dev',


### PR DESCRIPTION
As fluent_contents/plugins/picture/migrations/0001_initial.py migration uses django-any-urlfield and django-any-imagefield applications extra dependencies are required.

By 2.1.0 version I assumed next django-any-urlfield release, compatible with django 1.7 (pull request pending).
