### PR TITLE
fix "cannot import name 'flatatt'" on 1.11

### DIFF
--- a/fluent_contents/forms/widgets.py
+++ b/fluent_contents/forms/widgets.py
@@ -3,7 +3,7 @@ from django.contrib.admin.widgets import AdminTextareaWidget
 from django.forms.widgets import Widget
 from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
-from django.forms.widgets import flatatt
+from django.forms.utils import flatatt
 from django.utils.html import escape
 from fluent_contents.models import get_parent_language_code
 from fluent_contents.models.managers import get_parent_active_language_choices


### PR DESCRIPTION
see https://github.com/carltongibson/django-filter/issues/673 for context