### PR TITLE
Updated example to resolve error with deprecated render_to_response

### DIFF
--- a/example/simplecms/views.py
+++ b/example/simplecms/views.py
@@ -1,5 +1,5 @@
 from django.http import Http404
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.template.context import RequestContext
 from simplecms.models import Page
 

--- a/example/simplecms/views.py
+++ b/example/simplecms/views.py
@@ -13,6 +13,6 @@ def page_detail(request, path):
     except Page.DoesNotExist:
         raise Http404("No page found for the path '%s'" % stripped)
 
-    return render_to_response(page.template_name, {
+return render(request, page.template_name, {
         'simplecms_page': page,
-    }, context_instance=RequestContext(request))
+        })


### PR DESCRIPTION
Hi I just thought to share a small update I made to the example. simplecms.views.py was giving an error when rendering new pages due to django shortcuts render_to_response being deprecated in v2.0. I replaced it with render() and is now working,