### PR TITLE
Missing settings import occured in undefined runntime error

### DIFF
--- a/fluent_contents/models/managers.py
+++ b/fluent_contents/models/managers.py
@@ -4,6 +4,7 @@ The manager classes are accessed via ``Placeholder.objects``.
 import six
 
 from future.builtins import str
+from django.conf import settings
 from django.db import models
 from django.contrib.contenttypes.models import ContentType
 from django.utils.translation import get_language


### PR DESCRIPTION
models/managers.py were missing an import statement for a `django.conf.settings`. Settings is used in line 295 for getting parent SITE_ID