### PR TITLE
fix Django 3.0 deprecation warnings

### DIFF
--- a/docs/newplugins/models.rst
+++ b/docs/newplugins/models.rst
@@ -30,7 +30,7 @@ the rest is just standard Django model code.
 .. code-block:: python
 
   from django.db import models
-  from django.utils.translation import ugettext_lazy as _
+  from django.utils.translation import gettext_lazy as _
   from fluent_contents.models import ContentItem
 
   class AnnouncementBlockItem(ContentItem):
@@ -60,7 +60,7 @@ The :file:`content_plugins.py` file can contain multiple plugins, each should in
 
 .. code-block:: python
 
-  from django.utils.translation import ugettext_lazy as _
+  from django.utils.translation import gettext_lazy as _
   from fluent_contents.extensions import plugin_pool, ContentPlugin
   from .models import AnnouncementBlockItem
 
@@ -109,7 +109,7 @@ This can be used to generate the HTML:
 
     By default, the output of plugins is cached; changes to the template file
     are only visible when the model is saved in the Django admin.
-    You can set :ref:`FLUENT_CONTENTS_CACHE_OUTPUT` to ``False``, or use 
+    You can set :ref:`FLUENT_CONTENTS_CACHE_OUTPUT` to ``False``, or use
     the :attr:`~fluent_contents.extensions.ContentPlugin.cache_output` setting temporary in development.
     The setting is enabled by default to let plugin authors make a conscious decision about caching
     and avoid unexpected results in production.

--- a/fluent_contents/extensions/pluginbase.py
+++ b/fluent_contents/extensions/pluginbase.py
@@ -18,7 +18,7 @@ from django.template.loader import render_to_string
 from django.utils.functional import cached_property
 from django.utils.html import escape, linebreaks
 from django.utils.translation import get_language
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from future.builtins import str
 from future.utils import with_metaclass
 
@@ -216,7 +216,7 @@ class ContentPlugin(with_metaclass(PluginMediaDefiningClass, object)):
 
     #: The category title to place the plugin into.
     #: This is only used for the "Add Plugin" menu.
-    #: You can provide a string here, :func:`~django.utils.translation.ugettext_lazy`
+    #: You can provide a string here, :func:`~django.utils.translation.gettext_lazy`
     #: or one of the predefined constants (:attr:`MEDIA`, :attr:`INTERACTIVITY:`, :attr:`PROGRAMMING` and :attr:`ADVANCED`).
     category = None
 

--- a/fluent_contents/models/db.py
+++ b/fluent_contents/models/db.py
@@ -9,7 +9,7 @@ from django.db import connection, models
 from django.db.backends.utils import truncate_name
 from django.dispatch import receiver
 from django.utils.functional import cached_property
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from future.utils import PY3, python_2_unicode_compatible, with_metaclass
 from parler.models import TranslatableModel
 from parler.signals import post_translation_delete

--- a/fluent_contents/panels.py
+++ b/fluent_contents/panels.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 from debug_toolbar.panels import Panel
 from debug_toolbar.utils import ThreadCollector
 from django.contrib.contenttypes.models import ContentType
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from fluent_contents.extensions import PluginNotFound
 from fluent_contents.models import ContentItem

--- a/fluent_contents/plugins/code/models.py
+++ b/fluent_contents/plugins/code/models.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from django.db import models
 from django.utils.text import Truncator
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from fluent_utils.dry.fields import HideChoicesCharField
 from future.utils import python_2_unicode_compatible
 

--- a/fluent_contents/plugins/commentsarea/models.py
+++ b/fluent_contents/plugins/commentsarea/models.py
@@ -1,7 +1,7 @@
 from django.db import models
 from django.db.models import signals
 from django.dispatch import receiver
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from fluent_utils.softdeps.comments import get_model as get_comment_model
 from fluent_utils.softdeps.comments import signals as comments_signals
 from future.utils import python_2_unicode_compatible

--- a/fluent_contents/plugins/disquswidgets/models.py
+++ b/fluent_contents/plugins/disquswidgets/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from future.utils import python_2_unicode_compatible
 
 from fluent_contents.models import ContentItem, ContentItemManager

--- a/fluent_contents/plugins/formdesignerlink/models.py
+++ b/fluent_contents/plugins/formdesignerlink/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from future.utils import python_2_unicode_compatible
 
 from fluent_contents.models import ContentItem, ContentItemManager

--- a/fluent_contents/plugins/gist/models.py
+++ b/fluent_contents/plugins/gist/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from future.builtins import str
 from future.utils import python_2_unicode_compatible
 

--- a/fluent_contents/plugins/googledocsviewer/models.py
+++ b/fluent_contents/plugins/googledocsviewer/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from future.utils import python_2_unicode_compatible
 
 from fluent_contents.models import ContentItem, ContentItemManager

--- a/fluent_contents/plugins/iframe/models.py
+++ b/fluent_contents/plugins/iframe/models.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from future.utils import python_2_unicode_compatible
 
 from fluent_contents.models import ContentItem, ContentItemManager

--- a/fluent_contents/plugins/markup/content_plugins.py
+++ b/fluent_contents/plugins/markup/content_plugins.py
@@ -10,7 +10,7 @@ This plugin supports several markup languages:
 """
 
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from fluent_contents.extensions import ContentPlugin, plugin_pool
 from fluent_contents.plugins.markup import appsettings, backend

--- a/fluent_contents/plugins/markup/models.py
+++ b/fluent_contents/plugins/markup/models.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.text import Truncator
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from future.utils import python_2_unicode_compatible
 
 from fluent_contents.forms import ContentItemForm

--- a/fluent_contents/plugins/oembeditem/fields.py
+++ b/fluent_contents/plugins/oembeditem/fields.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import ValidationError
 from django.db.models import URLField
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from fluent_contents.plugins.oembeditem import backend
 

--- a/fluent_contents/plugins/oembeditem/models.py
+++ b/fluent_contents/plugins/oembeditem/models.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from future.builtins import str
 from future.utils import python_2_unicode_compatible
 from micawber import ProviderException

--- a/fluent_contents/plugins/picture/models.py
+++ b/fluent_contents/plugins/picture/models.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from future.builtins import str
 from future.utils import python_2_unicode_compatible
 

--- a/fluent_contents/plugins/rawhtml/models.py
+++ b/fluent_contents/plugins/rawhtml/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 from django.utils.html import strip_tags
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from future.utils import python_2_unicode_compatible
 
 from fluent_contents.models import ContentItem, ContentItemManager

--- a/fluent_contents/plugins/sharedcontent/admin.py
+++ b/fluent_contents/plugins/sharedcontent/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from fluent_utils.dry.admin import MultiSiteAdminMixin
 from parler.admin import TranslatableAdmin
 

--- a/fluent_contents/plugins/sharedcontent/models.py
+++ b/fluent_contents/plugins/sharedcontent/models.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from future.builtins import str
 from future.utils import python_2_unicode_compatible
 from parler.models import TranslatableModel, TranslatedFields

--- a/fluent_contents/plugins/text/models.py
+++ b/fluent_contents/plugins/text/models.py
@@ -1,7 +1,7 @@
 from django.db import models
 from django.utils.html import strip_tags
 from django.utils.text import Truncator
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from future.utils import python_2_unicode_compatible
 
 from fluent_contents.extensions import PluginHtmlField

--- a/fluent_contents/plugins/twitterfeed/models.py
+++ b/fluent_contents/plugins/twitterfeed/models.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from future.utils import python_2_unicode_compatible
 
 from fluent_contents.models import ContentItemManager

--- a/fluent_contents/templatetags/placeholder_tags.py
+++ b/fluent_contents/templatetags/placeholder_tags.py
@@ -1,14 +1,32 @@
 import warnings
 
+from django.template import Library
+
 from .fluent_contents_tags import (
     PagePlaceholderNode,
     RenderPlaceholderNode,
-    page_placeholder,
-    register,
-    render_placeholder,
+    page_placeholder as new_page_placeholder,
+    render_placeholder as new_render_placeholder,
 )
 
-warnings.warn(
-    "fluent_contents.templatetags.placeholder_tags is deprecated; use fluent_contents_tags instead",
-    DeprecationWarning,
-)
+
+register = Library()
+
+
+def warn():
+    warnings.warn(
+        "fluent_contents.templatetags.placeholder_tags is deprecated; use fluent_contents_tags instead",
+        DeprecationWarning,
+    )
+
+
+@register.tag
+def page_placeholder(parser, token):
+    warn()
+    return new_page_placeholder(parser, token)
+
+
+@register.tag
+def render_placeholder(parser, token):
+    warn()
+    return new_render_placeholder(parser, token)

--- a/fluent_contents/utils/search.py
+++ b/fluent_contents/utils/search.py
@@ -1,7 +1,12 @@
 """
 Internal utils for search.
 """
-from django.utils.encoding import force_text
+import sys
+
+if sys.version_info > (3, 0):
+    from django.utils.encoding import force_str
+else:
+    from django.utils.encoding import force_text as force_str
 from django.utils.html import strip_tags
 from future.utils import string_types
 
@@ -34,7 +39,7 @@ def get_cleaned_string(data):
     """
     Cleanup a string/HTML output to consist of words only.
     """
-    return strip_tags(force_text(data))
+    return strip_tags(force_str(data))
 
 
 def clean_join(separator, iterable):

--- a/fluent_contents/utils/validators.py
+++ b/fluent_contents/utils/validators.py
@@ -1,7 +1,7 @@
 import re
 
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 def validate_html_size(value):


### PR DESCRIPTION
Hey there!

Django 3.0 brings a couple of deprecation warnings that this PR fixes.

Additionally, previous deprecation warning mechanism in `placeholder_tags.py` threw a warning whether it was used or not, so I adjusted it slightly to only emit the warning if a template tag is used.